### PR TITLE
chore: Log events with missing timestamp

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11,9 +11,7 @@ interface UnduplicatesPluginInterface {
 }
 
 const stringifyEvent = (event: PluginEvent): string => {
-    return `(${randomUUID().toString()}; project #${event.team_id}). Event "${event.event}" @ ${
-        event.timestamp
-    } for user ${event.distinct_id}.`
+    return `(${randomUUID().toString()}; project #${event.team_id}). Event "${event.event}" @ ${event.timestamp} for user ${event.distinct_id}.`
 }
 
 const byteToHex: string[] = []
@@ -55,7 +53,7 @@ const plugin: Plugin<UnduplicatesPluginInterface> = {
 
         if (!event.timestamp) {
             console.info(
-                'Received event without a timestamp, the event will not be processed because deduping will not work.'
+                `Received event without a timestamp: ${stringifiedEvent}, the event will not be processed because deduping will not work.`
             )
             return event
         }


### PR DESCRIPTION
Ideally, most events should be de-duplicated, so if one wasn't, we want to know why.

Latest commit removed debug logs to reduce log volume. However, we need this information to debug errors. So, let's add the stringified event o the info log outputted when an event is not de-duplicated. This way, we have the information we need without adding new log lines.
